### PR TITLE
feature: validator "after" hooks 

### DIFF
--- a/src/FormRequest.php
+++ b/src/FormRequest.php
@@ -49,6 +49,15 @@ abstract class FormRequest extends Request
         throw new ValidationException($this->validator, $this->errorResponse());
     }
 
+    /**
+     * Allows to call any of validator methods
+     * before the validation rules are actually evaluated.
+     */
+    protected function withValidator(): void
+    {
+        //
+    }
+
     protected function validationPassed()
     {
         //
@@ -67,6 +76,7 @@ abstract class FormRequest extends Request
 
         $this->validator = $this->app->make('validator')
                                      ->make($this->all(), $this->rules(), $this->messages(), $this->attributes());
+        $this->withValidator();
 
         if ($this->validator->fails()) {
             $this->validationFailed();

--- a/tests/Extensions/DontUseThisTestRequest.php
+++ b/tests/Extensions/DontUseThisTestRequest.php
@@ -63,4 +63,11 @@ class DontUseThisTestRequest extends FormRequest
             'age' => 'oldness',
         ];
     }
+
+    protected function withValidator(): void
+    {
+        $this->validator->sometimes('name', 'starts_with:old', function ($input) {
+            return $input->age >= 100;
+        });
+    }
 }

--- a/tests/FormRequestTest.php
+++ b/tests/FormRequestTest.php
@@ -97,4 +97,14 @@ class FormRequestTest extends TestCase
         $this->assertArrayHasKey('faults', $response);
         $this->assertArrayHasKey('note', $response);
     }
+
+    public function testWithValidator()
+    {
+        $response = $this->post('form-request', ['name' => 'young Harry', 'age' => 112,])
+            ->seeStatusCode(422)
+            ->response
+            ->getData(true);
+        $this->assertIsString($response['message']);
+        $this->assertIsArray($response['errors']);
+    }
 }


### PR DESCRIPTION
Hi! 👋
I'd like to suggest the ability of adding extra validation rules after validator instance is created.
It could be very handy for [complex conditional validation rules](https://laravel.com/docs/8.x/validation#complex-conditional-validation).
In fact, I tried to implement [Laravel form request hooks](https://laravel.com/docs/8.x/validation#adding-after-hooks-to-form-requests).


**What was done:**
 - added new feature;
 - added feature test.
